### PR TITLE
avoid repeated builtin calls

### DIFF
--- a/colcon_bash/shell/template/package.bash.em
+++ b/colcon_bash/shell/template/package.bash.em
@@ -23,24 +23,28 @@ colcon_package_source_bash_script() {
 }
 
 
-# a bash script is able to determine its own path
+# a bash script is able to determine its own path if necessary
 # the prefix is two levels up from the package specific share directory
-COLCON_CURRENT_PREFIX=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`/../.." > /dev/null && pwd)
+if [ -z "$COLCON_CURRENT_PREFIX" ]; then
+  COLCON_CURRENT_PREFIX=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`/../.." > /dev/null && pwd)
+fi
+@[if hooks]@
+_package_COLCON_CURRENT_PREFIX=$COLCON_CURRENT_PREFIX
+@[end if]@
 
 colcon_package_source_bash_script "$COLCON_CURRENT_PREFIX/share/@(pkg_name)/package.sh"
-
-@[for i, hook in enumerate(hooks)]@
-@[  if i == 0]@
-COLCON_CURRENT_PREFIX=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`/../.." > /dev/null && pwd)
-
-@[end if]@
-colcon_package_source_bash_script "$COLCON_CURRENT_PREFIX/@(hook[0])"@
-@[  for hook_arg in hook[1]]@
- @(hook_arg)@
-@[  end for]
-@[end for]@
 @[if hooks]@
 
-unset COLCON_CURRENT_PREFIX
+COLCON_CURRENT_PREFIX=$_package_COLCON_CURRENT_PREFIX
+
+@[  for hook in hooks]@
+colcon_package_source_bash_script "$COLCON_CURRENT_PREFIX/@(hook[0])"@
+@[    for hook_arg in hook[1]]@
+ @(hook_arg)@
+@[    end for]
+@[  end for]@
+
+unset _package_COLCON_CURRENT_PREFIX
 @[end if]@
+unset COLCON_CURRENT_PREFIX
 unset colcon_package_source_bash_script

--- a/colcon_bash/shell/template/prefix.bash.em
+++ b/colcon_bash/shell/template/prefix.bash.em
@@ -22,17 +22,15 @@ colcon_prefix_source_bash_script() {
   unset _colcon_prefix_source_bash_script
 }
 
-
-@[end if]@
-@[for i, pkg_name in enumerate(pkg_names)]@
-@[  if i == 0]@
 # a bash script is able to determine its own path
-@[  end if]@
-COLCON_CURRENT_PREFIX=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`@('' if merge_install else ('/' + pkg_name))" > /dev/null && pwd)
+_prefix_COLCON_CURRENT_PREFIX=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" > /dev/null && pwd)
+
+@[  for pkg_name in pkg_names]@
+COLCON_CURRENT_PREFIX=$_prefix_COLCON_CURRENT_PREFIX@('' if merge_install else ('/' + pkg_name))
 colcon_prefix_source_bash_script "$COLCON_CURRENT_PREFIX/share/@(pkg_name)/package.bash"
 
-@[end for]@
-@[if pkg_names]@
+@[  end for]@
 unset COLCON_CURRENT_PREFIX
+unset _prefix_COLCON_CURRENT_PREFIX
 unset colcon_prefix_source_bash_script
 @[end if]@


### PR DESCRIPTION
For larger workspaces the time for each `builtin` call to determine the current prefix path adds up.

This patch only determine the current prefix path once in the `prefix` file and then reuses that information. The `package` file now only determines the current prefix path if it is not already set from the outside.

This cuts down the time to source the `prefix.bash` file in a large workspace by half.