### PR TITLE
Fix the default value for create_hook_set_value()

### DIFF
--- a/colcon_bash/shell/bash.py
+++ b/colcon_bash/shell/bash.py
@@ -72,7 +72,7 @@ class BashShell(ShellExtensionPoint):
             ('%s.bash' % env_hook_name)
         logger.info("Creating environment hook '%s'" % hook_path)
         if value == '':
-            value = '$COLCON_PREFIX_PATH'
+            value = '$COLCON_CURRENT_PREFIX'
         expand_template(
             Path(__file__).parent / 'template' / 'hook_set_value.bash.em',
             hook_path, {'name': name, 'value': value})


### PR DESCRIPTION
The default value is supposed to be the current prefix only, `COLCON_CURRENT_PREFIX`, and not the concatenated list of all prefixes, `COLCON_PREFIX_PATH`. This fixes a bug(?) introduced in https://github.com/colcon/colcon-bash/pull/25. 

As originally commented at https://github.com/colcon/colcon-ros/pull/95#issuecomment-1435102381:

> With the patches
> 
> * [standardize behavior when passing an empty string colcon-core#304](https://github.com/colcon/colcon-core/pull/304) and
> * [standardize behavior when passing an empty string colcon-bash#25](https://github.com/colcon/colcon-bash/pull/25)
> 
> for the various shells the value `''` passed to `create_hook_set_value()` is replaced by `$COLCON_PREFIX_PATH`, so the concatenated list of all colcon workspaces separted with colons. But before this patch the value was `$COLCON_CURRENT_PREFIX`, a single path only, and that is also what is required to set `CATKIN_ENV_HOOK_WORKSPACE` [here](https://github.com/colcon/colcon-ros/blob/f1967980138c3fe191c7b9d7badb445e4e419aa2/colcon_ros/task/catkin/build.py#L102-L106) to mimic the behavior of catkin. Only for 1st-level workspaces and if `COLCON_PREFIX_PATH` was initially empty the difference does not matter, because the values of `COLCON_PREFIX_PATH` and `COLCON_CURRENT_PREFIX` are the same.
> 
> Is this a bug? At least `CATKIN_ENV_HOOK_WORKSPACE` is not set in the same way as with catkin in a 2nd- or higher level workspace with catkin env-hooks when it is built with colcon. I am not sure what the implied behavior of passing an empty value for dsv is, but I guess it should have been `$COLCON_CURRENT_PREFIX` for [colcon/colcon-core#304](https://github.com/colcon/colcon-core/pull/304) and [colcon/colcon-bash#25](https://github.com/colcon/colcon-bash/pull/25)?
> 
> For a package named `my_package` with an env-hook named `foo.sh` that prints `CATKIN_ENV_HOOK_WORKSPACE`, built in `/path/to/my/workspace` with `COLCON_PREFIX_PATH=/opt/ros/noetic`:
> 
> ```shell
> $ set -x
> $ . /path/to/my/workspace/install/setup.sh
> [...]
> ++++ COLCON_CURRENT_PREFIX=/path/to/my/workspace/install
> ++++ _colcon_prefix_sh_source_script /path/to/my/workspace/install/share/my_package/hook/catkin_env_hook_workspace.sh
> ++++ '[' -f /path/to/my/workspace/install/share/my_package/hook/catkin_env_hook_workspace.sh ']'
> ++++ '[' -n '' ']'
> ++++ . /path/to/my/workspace/install/share/my_package/hook/catkin_env_hook_workspace.sh
> ++++ . /path/to/my/workspace/install/share/my_package/catkin_env_hook/foo.sh
> +++++ echo 'CATKIN_ENV_HOOK_WORKSPACE = /path/to/my/workspace/install:/opt/ros/noetic'
> CATKIN_ENV_HOOK_WORKSPACE = /path/to/my/workspace/install:/opt/ros/noetic
> ```

> > I am not sure what the implied behavior of passing an empty value for dsv is, but I guess it should have been `$COLCON_CURRENT_PREFIX` for [colcon/colcon-core#304](https://github.com/colcon/colcon-core/pull/304) and [colcon/colcon-bash#25](https://github.com/colcon/colcon-bash/pull/25)?
> 
> For dsv an empty value is replaced by the `prefix` [here](https://github.com/colcon/colcon-core/blob/4e104116ac87c6ecf4d6c2c15f4b436c0fe59992/colcon_core/shell/template/prefix_util.py.em#L274), so a single path only.